### PR TITLE
Fix chain logos

### DIFF
--- a/container_env_files/cfg.env
+++ b/container_env_files/cfg.env
@@ -41,4 +41,5 @@ CGW_FLUSH_TOKEN=some_super_random_token
 
 CSRF_TRUSTED_ORIGINS="http://localhost:8000"
 
-MEDIA_URL = "http://localhost:8000/cfg/media/"
+# MEDIA_URL = "http://localhost:8000/cfg/media/"
+MEDIA_BASE_URL = "http://localhost:8000/cfg/media/"

--- a/container_env_files/cgw.env
+++ b/container_env_files/cgw.env
@@ -5,10 +5,9 @@ HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS=60000
 # The base url for the Safe Config Service
 SAFE_CONFIG_BASE_URI=http://nginx:8000/cfg
 
-# Exchange Rates
-# The base Exchange Rate API to be used.
-EXCHANGE_API_BASE_URI=http://api.exchangeratesapi.io/v1
-EXCHANGE_API_KEY=your_exchange_rate_api_token
+# RPC Provider
+# The RPC provider to be used.
+INFURA_API_KEY=''
 
 # Redis
 # The host name of where the Redis instance is running
@@ -37,10 +36,6 @@ ALERTS_PROVIDER_API_KEY=''
 ALERTS_PROVIDER_ACCOUNT=''
 ALERTS_PROVIDER_PROJECT=''
 
-# Relay Provider
-RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=''
-RELAY_PROVIDER_API_KEY_SEPOLIA=''
-
 # Email handling
 # Please note that the Safe CGW is currently using Pushwoosh as the email services provider.
 # Refer to the provider's official documentation to set up emailing.
@@ -50,3 +45,14 @@ EMAIL_API_KEY=''
 EMAIL_TEMPLATE_RECOVERY_TX=''
 EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=''
 EMAIL_TEMPLATE_VERIFICATION_CODE=''
+
+# Relay Provider
+# The relay provider to be used.
+# (default='https://api.gelato.digital')
+# RELAY_PROVIDER_API_BASE_URI=
+# (default=5)
+# RELAY_THROTTLE_LIMIT=
+# The API key to be used per chain.
+RELAY_PROVIDER_API_KEY_ARBITRUM_ONE=''
+RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=''
+RELAY_PROVIDER_API_KEY_SEPOLIA=''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,10 +131,11 @@ services:
 
   # Safe Config Service
   cfg-web:
-    image: safeglobal/safe-config-service:${CFG_VERSION}
+    image: hemilabs/safe-config-service:${CFG_VERSION}
     tty: true
     volumes:
       - nginx-shared-cfg:/nginx
+      - ./data/cfg-media:/app/src/media
     env_file:
       - container_env_files/cfg.env
     depends_on:


### PR DESCRIPTION
This PR brings the latest change from upstream so the Configuration service works properly and then fixes the chain logos in the UI when running locally using `docker compose`.

Highlights:

- Use the new Configuration service image that contains [a patch to properly build the logo URLs](https://github.com/hemilabs/safe-config-service/pull/1/commits/f42be6314018d688fdc89e5cdc7cddf9e2dfe64f).
- Set the `MEDIA_BASE_URL` to build the logo URLs with the proper host and base path.
- Unset `MEDIA_URL` so it defaults to `/media/` and the files are stored/retrieved properly by Django.
- Map `/app/src/media` in the Configuration service container to a volume so the uploaded images are persisted.

Related to https://github.com/hemilabs/safe-wallet-web/issues/4.